### PR TITLE
adjust: disable refresh baha token in production

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -27,7 +27,8 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         $schedule->call(fn () => (new RefreshBahaToken)->handle())
-            ->dailyAt('22:00');
+            ->dailyAt('22:00')
+            ->when(fn () => !app()->environment('production'));
 
         $schedule->call(fn () => (new ScrapePostsFromSearchTitle)->handle())
             ->dailyAt('23:00')


### PR DESCRIPTION
using browser crawler on remote server still cannot bypass baha's anti-crawler 
but using browser crawler in local env is feasible